### PR TITLE
Add debug-order-sensitive-pytest skill

### DIFF
--- a/skills/debug-order-sensitive-pytest/SKILL.md
+++ b/skills/debug-order-sensitive-pytest/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: debug-order-sensitive-pytest
+description: "Debug and fix pytest tests that pass alone but fail when the suite runs in a different order. Use when: (1) tests are flaky under shuffled/randomized order, (2) a failing test passes in isolation but fails in the full suite, or (3) tests leak global state (sys.modules, module reloads, shared singletons, env vars) across tests."
+---
+
+# Debug Order-Sensitive Pytest Failures
+
+Find and fix tests that pass on their own but fail when pytest runs in a different order. The suite is green again only after every leaked-global-state polluter is fixed and both the shuffled and the normal runs pass.
+
+## Quick quality checklist
+
+- Repro order is pinned with a fixed seed and printed so any failure is reproducible
+- Always bisect with the failing target test **appended** to every slice (a failing window can contain multiple polluters)
+- Instrumented runs are only hints — always confirm on clean runs
+- No private data, paths, or project-specific test names in this skill
+
+## When to use
+
+- A test fails only in the full suite but passes standalone with `pytest <file>` or `pytest <nodeid>`
+- A CI job that randomizes test order (pytest-randomly, custom shuffle) is flaky
+- You suspect a test mutates `sys.modules`, reloads a module, or mutates a shared module-level singleton without restoring it
+
+## Required tools / APIs
+
+- Python 3.8+ and pytest (no external API)
+- Optional: a shuffling runner (pytest-randomly, or a local seeded-shuffle plugin, described below)
+
+## Steps
+
+### 1. Reproduce with a fixed-seed shuffle
+
+Pin the order so every bisection uses the exact same failing sequence. Use pytest-randomly:
+
+```bash
+pip install pytest-randomly
+python -m pytest -q --randomly-seed=42 -p no:cacheprovider --tb=no | tee order.log
+```
+
+Or, for a repo that already has a seeded-shuffle runner (e.g. `tests/run_order_report.py --seed 42`), use it. If neither exists, add a tiny local plugin that shuffles collection with a fixed seed:
+
+```python
+# shuffle42.py  (load with: python -m pytest -p shuffle42 ...)
+import random
+
+def pytest_collection_modifyitems(items):
+    random.Random(42).shuffle(items)
+```
+
+Record the failing nodeids from the log. The seed must be printed/stored so the order is reproducible.
+
+### 2. Dump the shuffled order to a file
+
+Every bisection slice must come from the **same shuffled order**. The shuffle must be re-applied deterministically to the same collected list, so dump the exact order once:
+
+```bash
+python -m pytest --collect-only -q 2>/dev/null | grep "::" > collected.txt
+python - <<'PY'
+import random
+ids = [l.strip() for l in open("collected.txt") if l.strip() and "::" in l]
+random.Random(42).shuffle(ids)
+open("shuffled.txt", "w").write("\n".join(ids) + "\n")
+PY
+```
+
+Now the order in `shuffled.txt` is exactly the order pytest-randomly/your plugin ran, and every slice is reproducible.
+
+### 3. Bisect with ordered windows (target test always appended)
+
+A failing region can hold **several independent polluters**, so a window and its bisected halves can each pass while the full window fails. The fix: run exact windows and always **append the failing target test** to the slice, so the target is what you observe.
+
+```python
+# run_slice.py -- run a window of shuffled.txt, always appending the target test
+import random, sys
+from pathlib import Path
+ids = [l.strip() for l in Path("shuffled.txt").read_text().splitlines() if l.strip()]
+random.Random(42).shuffle(ids)
+
+class OrderPlugin:
+    def __init__(self, order):
+        self.order = order
+    def pytest_collection_modifyitems(self, items):
+        by_id = {i.nodeid: i for i in items}
+        items[:] = [by_id[n] for n in self.order if n in by_id]
+
+def main():
+    import pytest
+    start, end = int(sys.argv[1]), int(sys.argv[2])
+    window = ids[start:end]
+    target = sys.argv[3]
+    for nodeid in ids:
+        if nodeid == target and nodeid not in window:
+            window.append(nodeid)
+    return pytest.main(["-q", "-p", "no:cacheprovider", "--tb=short"],
+                       plugins=[OrderPlugin(window)])
+
+main()
+```
+
+Usage:
+
+```bash
+python run_slice.py 0 1000 'tests/test_thing.py::test_target'   # window + target appended
+python run_slice.py 0 500  'tests/test_thing.py::test_target'   # left half still fails?
+python run_slice.py 500 1000 'tests/test_thing.py::test_target' # right half still fails?
+```
+
+A slice that passes with the target removed but fails with it present means the polluter is inside that window. Halve repeatedly. If both halves pass but the combined window fails, a two-test interaction is at play: keep widening one boundary to find the second polluter.
+
+### 4. Check the common leak patterns
+
+Once a polluting test is isolated, look for these state leaks and fix them at the source:
+
+- **`sys.modules.pop(name)` without restore** — any later test doing `monkeypatch.setattr("pkg.mod.X", ...)` triggers a *fresh import* whose module object differs from the one collected tests captured. Fix: snapshot `{name: sys.modules.get(name) for name in (...)}` before, and restore the same object in a `finally` (leave absent if it was absent).
+- **`importlib.reload(mod)`** — reload re-executes code in the *same* module `__dict__` in place; names like module-level caches get **rebound to new objects**, so module attributes captured earlier by `from mod import CACHE` become stale (`.clear()` clears an orphan). Fix: snapshot the module `__dict__` (and env vars) before, restore them after — restoring `sys.modules` entries is not enough.
+- **Shared module-level singletons** — a module-level `APIRouter`, cache dict, registry, or DB engine that tests mutate and never restore. Fix: `monkeypatch.setattr` for restorable mutations, or a fixture that snapshots/restores; never leave a test-only registration behind.
+- **`monkeypatch.setattr("pkg.mod.fn", ...)` vs `from pkg.mod import fn`** — the patch lands on the module attribute; a pre-imported `fn` reference still points at the original. Patch what the code under test actually calls.
+
+### 5. Instrument to confirm (then verify clean)
+
+To find *which* test mutates a module, add a read-only hook that records module/attribute identity after every test. Note that pytest calls later-registered plugins first: a plugin's `pytest_runtest_teardown` fires **before** core fixture teardown. To observe post-teardown (post-restore) state, use the report hook:
+
+```python
+class StateTrack:
+    def __init__(self):
+        self.orig = None
+    def pytest_sessionstart(self, session):
+        import pkg.mod
+        self.orig = sys.modules.get("pkg.mod")
+    def pytest_runtest_makereport(self, item, call):
+        if call.when != "teardown" or call.excinfo is not None:
+            return
+        mod = sys.modules.get("pkg.mod")
+        if mod is not self.orig:
+            print(f"CHANGED after {item.nodeid}: {id(mod) if mod else 'ABSENT'}")
+```
+
+The trace shows exactly which test evicts/replaces the module. **Warning:** instrumented runs can change timing/state and diverge from the real suite — always confirm a fix with clean (uninstrumented) runs.
+
+### 6. Verify
+
+```bash
+# shuffled suite, same seed as step 1 — must exit 0
+python -m pytest -q --randomly-seed=42 -p no:cacheprovider --tb=no
+
+# normal (unshuffled) suite — must still exit 0
+python -m pytest -q -p no:cacheprovider --tb=no
+
+# the previously flaky file standalone — must pass
+python -m pytest tests/test_thing.py -q -p no:cacheprovider --tb=no
+```
+
+## Output format
+
+Report for each fixed polluter:
+
+- Polluting test nodeid + position in the shuffled order
+- The leak mechanism (one of: sys.modules pop/replace, in-place module reload, shared singleton, stale import reference)
+- The fix (what was snapshotted/restored or monkeypatched)
+- Final verification: shuffled suite exit code + normal suite exit code
+
+## Troubleshooting
+
+**Symptom: the failing window passes now but a full run still fails.**
+- A region can contain multiple polluters. Re-dump the failing nodeids from the latest full run and re-bisect each one with the target appended.
+
+**Symptom: instrumented run shows thousands of errors / diverges.**
+- The instrumentation itself disturbs state. Drop it and bisect with the plain window runner instead; use the instrument only to confirm a suspected mechanism, never as the source of truth.
+
+**Symptom: same window fails sometimes, passes other times.**
+- If both runners shuffle the same file with the same seed, the order is identical — double-check that both used the same list (extra/duplicate lines in the ids file change the shuffle). Verify the shuffled ids file matches the actual run order before trusting any slice.
+
+**Symptom: `pytest_runtest_teardown` shows state already restored.**
+- Your hook runs before core fixture teardown. Use `pytest_runtest_makereport` with `call.when == "teardown"` and `call.excinfo is None` to observe post-restore state.
+
+## See also
+
+- [../pytest-isolation-conventions/SKILL.md](../pytest-isolation-conventions/SKILL.md) — Coding conventions that prevent this class of bug (if added)
+

--- a/skills/facebook-page-manager/SKILL.md
+++ b/skills/facebook-page-manager/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: facebook-page-manager
+description: "Build an autonomous Facebook page management agent in Node.js using the Graph API (content generation, scheduling, comment auto-replies, analytics, monetization readiness), plus the developer-app/token setup flow. Use when the user wants to automate or monetize a Facebook page."
+---
+
+# Facebook Page Manager Agent
+
+Builds a standalone Node.js agent that manages a Facebook page: AI-drafted content,
+scheduled posting cadence, comment auto-replies, analytics, and monetization
+readiness tracking, controllable from Telegram.
+
+## When to use
+
+- User asks to "build a Facebook agent / automate a Facebook page / grow a page"
+- User wants page management, scheduling, or comment auto-replies
+- User wants monetization tracking or strategy for a page (Reels watch time, in-stream ads, subscribers)
+
+## Required tools / APIs
+
+- **Facebook Graph API** (free): page posting, scheduling, comments, insights. Requires a Facebook Developer app + user token.
+- **Local LLM via ollama** (free, optional): content drafting. Any OpenAI-compatible endpoint works.
+- **Telegraf** (free): optional Telegram control bot: `npm install telegraf`
+- **node-cron** (free): scheduler tick: `npm install node-cron`
+
+```bash
+npm install telegraf node-cron dotenv
+```
+
+## Skills
+
+### 1. Set up credentials (the 90% blocker)
+
+1. Create a developer app at https://developers.facebook.com → My Apps → Create App → Business type. Add the **Facebook Login** product.
+2. Grant the user token these permissions (work for pages you administer, no app review needed): `pages_show_list`, `pages_manage_posts`, `pages_read_engagement`, `pages_manage_engagement`, `read_insights`.
+3. Get a token in the **Graph API Explorer** (select your app → permissions → Generate Access Token).
+4. Exchange for a long-lived token (60 days) in a browser:
+   ```
+   https://graph.facebook.com/v21.0/oauth/access_token?grant_type=fb_exchange_token&client_id=APP_ID&client_secret=APP_SECRET&fb_exchange_token=USER_TOKEN
+   ```
+5. Page ID is under the page's **About** tab (or resolve via `GET /me/accounts`).
+
+### 2. Graph API client (Node.js)
+
+```javascript
+const BASE = "https://graph.facebook.com/v21.0";
+const TOKEN = process.env.FB_USER_TOKEN;
+
+async function graph(path, params = {}, method = "GET") {
+  const url = new URL(`${BASE}/${path}`);
+  if (method === "GET") Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  url.searchParams.set("access_token", TOKEN);
+  const opts = { method };
+  if (method !== "GET") {
+    opts.headers = { "Content-Type": "application/json" };
+    opts.body = JSON.stringify({ ...params, access_token: TOKEN });
+  }
+  const res = await fetch(url, opts);
+  const data = await res.json();
+  if (data.error) throw new Error(`Graph API ${data.error.code}: ${data.error.message}`);
+  return data;
+}
+
+// list pages
+const pages = await graph("me/accounts", { fields: "id,name,access_token" });
+// post text
+await graph("PAGE_ID/feed", { message: "hello" }, "POST");
+// schedule (published:false + unix seconds)
+await graph("PAGE_ID/feed", { message: "later", published: false, scheduled_publish_time: 1786500000 }, "POST");
+// comment replies (needs pages_manage_engagement)
+await graph("COMMENT_ID/replies", { message: "Thanks!" }, "POST");
+// insights (cumulative day-period values)
+await graph("PAGE_ID/insights", { metric: "page_fans,page_impressions,page_engaged_users,page_video_views", period: "day" });
+```
+
+Key facts:
+- Page-scoped tokens (`/PAGE_ID?fields=access_token` or from `/me/accounts`) don't expire for pages you administer; the user token lasts ~60 days.
+- `scheduled_publish_time` is **unix seconds**, not ms.
+- Errors come back as `{error:{code,message}}`; 190 = expired token, 200 = missing permission, 429 = rate limit (retry with backoff).
+
+### 3. Content + engagement loop
+
+- Draft posts with a local model (ollama OpenAI-compatible endpoint: `POST {OLLAMA_URL}/chat/completions` with `{model:"qwen2.5:1.5b", messages:[...]}`).
+- Posting cadence: a minute-level cron tick that (a) fires due jobs, then (b) tops up the next 24h to `POSTS_PER_DAY` slots.
+- Engagement: poll `GET PAGE_ID/feed?fields=comments.limit(10){id,message,from,created_time}`, reply once per unseen comment, track seen ids in a JSON store.
+- **Always support a DRY_RUN mode** (`DRY_RUN=true`) so the whole pipeline runs and is testable before real credentials exist.
+
+### 4. Monetization focus
+
+Track the classic in-stream-ads gates and drive them:
+- 10,000 followers
+- 30,000 × 1-minute video views in 60 days
+
+Report progress % toward each gate, deltas vs last snapshot, and advice (3s hooks, captions, save/share CTAs, video cadence). Remind users that Meta's actual eligibility (e.g. "Ads on Reels") has its own rolling rules — verify in the page's Professional Dashboard.
+
+## Output format
+
+The agent should report:
+- Page status: name, id, live/dry-run mode
+- Analytics: followers, impressions, engaged users, video views + deltas
+- Monetization: % toward each gate + concrete next actions
+- Scheduled jobs: id, status, time, preview
+
+Errors: `Graph API <code>: <message>` plus the fix (refresh token / grant permission).
+
+## Rate limits / Best practices
+
+- Back off on HTTP 429 / 5xx (retry up to 3x with exponential delay).
+- Never reply to the same comment twice — persist seen ids.
+- Keep a DRY_RUN flag and never hardcode tokens (`.env`, git-ignored).
+- Graph API tokens are credentials — never commit them, redact in logs.
+
+## Agent prompt
+
+```text
+You have Facebook Page Manager capability. When a user asks to build or run a Facebook page agent:
+1. Confirm whether they already have a Facebook Developer app + user token. If not, walk them through the setup flow above.
+2. Build the agent as a standalone Node service: Graph client, content generator (local ollama first), scheduler, engagement poller, analytics, monetization tracker.
+3. Ship with DRY_RUN=true so it runs before credentials exist; only flip to live after `doctor` checks pass.
+4. Track monetization gates and always verify eligibility rules in Meta's dashboard rather than promising monetization.
+```
+
+## Troubleshooting
+
+**`Graph API error 190` / "token expired"**
+- Re-run the `fb_exchange_token` step to refresh the long-lived user token.
+
+**`Graph API error 200` permission**
+- The token lacks a permission or the app needs review. Regenerate the token and re-approve permissions.
+
+**`403` on comment replies**
+- Missing `pages_manage_engagement`, or replying on a post you don't manage.
+
+**`429` rate limit**
+- Add exponential backoff and reduce poll frequency (Graph API ~600 calls/600s per token).
+
+## See also
+
+- [../using-telegram-bot/SKILL.md](../using-telegram-bot/SKILL.md) — Telegraf patterns used for the control bot

--- a/skills/zeroclaw-telegram-channel/SKILL.md
+++ b/skills/zeroclaw-telegram-channel/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: zeroclaw-telegram-channel
+description: "Diagnose and repair the ZeroClaw Telegram channel so the agent answers you from Telegram. Use when (1) Telegram pairing/bind codes loop forever, (2) the gateway websocket is in a restart loop, (3) channel doctor is healthy but messages/send fail with 401, or (4) you need to bind your Telegram identity to a channel alias."
+---
+
+# ZeroClaw Telegram Channel
+
+Gets the ZeroClaw agent reachable from Telegram: healthy channel, stable gateway, and your identity bound to the channel alias so the agent responds without endless `/bind` codes.
+
+## When to use
+
+- The agent keeps printing `Telegram pairing required. One-time bind code: NNNN` and never settles.
+- `zeroclaw gateway` component shows `Address already in use (os error 98)` with a high restart count.
+- `zeroclaw channel doctor` reports healthy, but `zeroclaw channel send` fails with `401 Unauthorized`.
+- You just added a bot token and want to bind your own Telegram account (username or numeric user ID) to a channel alias.
+
+## Required tools
+
+- `zeroclaw` CLI (config-dir defaults to `~/.zeroclaw`)
+- `systemctl --user` (daemon runs as a user systemd service)
+- `ss` (socket inspection)
+
+No external APIs required.
+
+## Skills
+
+### 1. Survey the current state
+
+```bash
+zeroclaw status                       # version, workspace, service, channels
+zeroclaw channel doctor               # per-channel health
+zeroclaw channel list                 # configured channels + aliases
+cat ~/.zeroclaw/state/daemon_state.json | python3 -c \
+  "import json,sys; d=json.load(sys.stdin); [print(k,'->',c.get('status'),(c.get('last_error') or '')[:60]) for k,c in d['components'].items()]"
+ps aux | grep "zeroclaw daemon" | grep -v grep   # count daemons — must be exactly ONE
+ss -tlnp | grep 42617                  # who owns the gateway port
+```
+
+### 2. Kill duplicate daemons (the #1 root cause)
+
+Two daemons (e.g. a homebrew install and a cargo install) both polling the same bot token and fighting over the gateway port break pairing and Telegram getUpdates. Keep the daemon whose workspace matches the CLI, disable the other:
+
+```bash
+systemctl --user list-units | grep -i zeroclaw
+systemctl --user stop homebrew.zeroclaw.service
+systemctl --user disable homebrew.zeroclaw.service
+systemctl --user restart zeroclaw.service
+sleep 6
+ps aux | grep "zeroclaw daemon" | grep -v grep   # expect exactly one
+ss -tlnp | grep 42617                            # expected to be held by the surviving PID
+```
+
+### 3. Fix the gateway / wss port collision
+
+If the `gateway` component binds `127.0.0.1:42617` while the `wss` (TLS websocket) component errors `binding WSS listener on 0.0.0.0:42617`, they collide on the same port. Move wss off the gateway port:
+
+```bash
+zeroclaw config set wss.port 42618
+systemctl --user restart zeroclaw.service
+sleep 6
+cat ~/.zeroclaw/state/daemon_state.json | python3 -c \
+  "import json,sys; d=json.load(sys.stdin); [print(k,'->',c.get('status')) for k,c in d['components'].items()]"
+```
+
+All components should report `ok` (including `gateway` and `wss`).
+
+### 4. Bind your Telegram identity to the channel alias
+
+`zeroclaw channel bind-telegram <identity> --alias <alias>` binds a Telegram username (no `@`) or numeric user ID into the channel allowlist. The alias must match `channels.telegram.<alias>` used by the agent — otherwise the agent keeps asking for approval.
+
+```bash
+# Find the alias the agent uses
+grep -A3 "^\[agents\." ~/.zeroclaw/config.toml | grep channels
+
+# Bind yourself (idempotent — re-running is safe)
+zeroclaw channel bind-telegram 123456789 --alias telegram1
+# → "✅ Telegram identity already bound to telegram.telegram1: 123456789"
+```
+
+### 5. Verify end-to-end
+
+```bash
+zeroclaw channel doctor
+zeroclaw channel bind-telegram <your-id> --alias telegram1   # confirm bound
+journalctl --user -u zeroclaw.service --no-pager | grep -iE "telegram|bind|pair" | tail
+```
+
+Then message the bot from Telegram; the agent should reply without a bind prompt.
+
+## Troubleshooting
+
+**Symptom: `zeroclaw channel send --channel-id telegram` fails with 401 Unauthorized**
+- Cause: the `--channel-id telegram` CLI path resolves to the `channels.telegram.default` alias. If that alias holds a stale/revoked bot token, sends 401 even though your real channel (`telegram1`) is healthy.
+- Fix: ignore it, or remove the dead `[channels.telegram.default]` section from `~/.zeroclaw/config.toml` and restart the daemon. Send through the real alias instead.
+
+**Symptom: gateway component `Address already in use`, restart count in the hundreds**
+- Cause: a second zeroclaw daemon owns the port.
+- Fix: identify with `ps aux | grep "zeroclaw daemon"`, stop/disable the duplicate service, restart the survivor.
+
+**Symptom: `Telegram pairing required. One-time bind code: NNNN` loops forever**
+- Cause: your identity isn't in the channel allowlist (and/or two daemons are fighting the same bot token).
+- Fix: run `zeroclaw channel bind-telegram <your-id> --alias telegram1`, ensure exactly one daemon, then restart it.
+
+## Agent prompt
+
+```text
+You have ZeroClaw Telegram channel repair capability. When a user reports the ZeroClaw Telegram channel not working:
+
+1. Run `zeroclaw channel doctor`, `zeroclaw channel list`, and `zeroclaw status` first.
+2. Count running daemons with `ps aux | grep "zeroclaw daemon"`; if more than one, disable the duplicate systemd user service and restart the survivor.
+3. Inspect `~/.zeroclaw/state/daemon_state.json`; if `gateway`/`wss` conflict on port 42617, move `wss.port` and restart.
+4. Confirm the user's Telegram identity is bound: `zeroclaw channel bind-telegram <id> --alias telegram1`.
+5. Verify all components are `ok` and report the final state.
+
+Never modify or decrypt bot tokens. Never bind an identity the user hasn't confirmed as their own.
+```
+
+## See also
+
+- [../using-telegram-bot/SKILL.md](../using-telegram-bot/SKILL.md) — Building standalone Telegram bots in Node.js with Telegraf (different use case: custom bots, not the ZeroClaw channel)

--- a/skills/zeroclaw-telegram-channel/SKILL.md
+++ b/skills/zeroclaw-telegram-channel/SKILL.md
@@ -131,6 +131,33 @@ journalctl --user -u zeroclaw.service --no-pager | grep -iE "mcp|skills" | tail
 ```
 Note: on CPU-only local models (e.g. `qwen2.5-coder:7b`), the agent loop is very slow — a simple prompt can take minutes. The tooling works; throughput is model-bound.
 
+## 7. Switch the bot to a cloud model provider (OpenRouter)
+
+Provider instances live at `providers.models.<provider>.<instance>` (e.g. `ollama.olla1`), referenced from `agents.<agent>.model_provider`.
+
+**Config:**
+```bash
+zeroclaw config set providers.models.openrouter.or1.model openai/gpt-4.1-mini --no-interactive
+zeroclaw config set providers.models.openrouter.or1.api_key sk-or-v1-... --no-interactive   # stored encrypted (enc2:)
+zeroclaw config set providers.models.openrouter.or1.max_tokens 8192 --no-interactive       # cap output budget
+zeroclaw config set agents.zeroclaw.model_provider openrouter.or1 --no-interactive
+zeroclaw models refresh --model-provider openrouter.or1   # expect "ok" + catalog fetched
+systemctl --user restart zeroclaw.service && sleep 8
+```
+
+**Key gotchas (learned the hard way):**
+- Validate keys with a REAL chat completion, not `GET /v1/models` — OpenRouter's model list is public and returns 200 even with a bogus key (false positive). A real call is `POST /api/v1/chat/completions` with `Authorization: Bearer <key>`; 401 = bad key, 402 = valid key but no credits.
+- Key-prefix validation: zeroclaw rejects `sk-proj-...` keys when the provider is `openrouter`. Use a matching key (OpenRouter = `sk-or-...`) or configure as an `openai` provider with `uri = "https://openrouter.ai/api/v1"` (OpenRouter is OpenAI-compatible). The latter skips live catalog refresh ("live model listing is not supported") but still serves requests.
+- `402 Payment Required` on first call with "can only afford N tokens": the default `max_tokens` is 65536. Cap it (e.g. 8192) or have the user add credits.
+- Key prefix mismatch on refresh says "looks like a openai key ... Set the correct provider-specific env var" — that's the validation gate, not a network fault.
+
+**Switch the companion app (Odysseus) to the same provider** (it discovers local ollama and falls back to it when its settings are empty):
+1. Add the endpoint via its own ORM (mirrors the UI's create path; API keys are Fernet-encrypted at rest via `data/.app_key`):
+   `src.database.SessionLocal` + `ModelEndpoint(id=uuid4()[:8], name="OpenRouter", base_url="https://openrouter.ai/api/v1", api_key=KEY, is_enabled=True, endpoint_kind="api", cached_models=json.dumps(["openai/gpt-4.1-mini"]), pinned_models=..., supports_tools=True, owner=None)`.
+2. Point its settings (`data/settings.json`) at the endpoint id: `default_endpoint_id`/`default_model`, `research_*`, `task_*`, `utility_*`, `vision_model`, `default_model_fallbacks=[{endpoint_id, model}]`, `teacher_model="<model>@<EndpointName>"`.
+3. Check per-user prefs don't override: `data/user_prefs.json` `_users.<name>` whitelisted keys beat globals.
+4. Restart `odysseus-ui.service`; verify with the app's own resolver: `resolve_endpoint("default", ...)` returns the OpenRouter chat URL.
+
 ## Troubleshooting
 
 **Symptom: `zeroclaw channel send --channel-id telegram` fails with 401 Unauthorized**

--- a/skills/zeroclaw-telegram-channel/SKILL.md
+++ b/skills/zeroclaw-telegram-channel/SKILL.md
@@ -87,6 +87,50 @@ journalctl --user -u zeroclaw.service --no-pager | grep -iE "telegram|bind|pair"
 
 Then message the bot from Telegram; the agent should reply without a bind prompt.
 
+## 6. Equip the bot with MCP servers, skill bundles, and media tools
+
+An agent is granted tools/skills explicitly — omissions are NOT grants.
+
+**Wire external MCP servers (e.g. an external app's stdio servers):**
+```bash
+# 1. Register each server (element must exist before its props resolve)
+curl -s -X POST "http://127.0.0.1:42617/api/config/map-key?path=mcp.servers&key=my_server" -H "Authorization: Bearer zc_selftest" -d '{}'
+# 2. Set command + args (env map may need a direct config.toml edit — CLI routing quirk)
+zeroclaw config set mcp.servers.my_server.command /usr/bin/python3 --no-interactive
+zeroclaw config set mcp.servers.my_server.args '["/opt/app/server.py"]' --no-interactive
+# 3. env block, e.g. owner scope + PYTHONPATH:
+#    env = { ODYSSEUS_MCP_MEMORY_OWNER = "admin", PYTHONPATH = "/opt/app" }
+# 4. Create an mcp_bundle and grant it — WITHOUT this the agent gets NO servers:
+zeroclaw config set mcp_bundles.mybundle.servers '["my_server"]' --no-interactive
+zeroclaw config set agents.<agent>.mcp_bundles '["mybundle"]' --no-interactive
+```
+`mcp.servers` is serialized as `[[mcp.servers]]` tables with `name`; the env map sometimes must be added directly in `~/.zeroclaw/config.toml`.
+
+**Curate a skill bundle:**
+```bash
+zeroclaw skills bundle add bot          # creates ~/.zeroclaw/shared/skills/bot/
+cp -r ~/open-skills/skills/<name> ~/.zeroclaw/shared/skills/bot/   # repeat per skill
+zeroclaw config set agents.zeroclaw.skill_bundles '["bot"]' --no-interactive
+```
+Skills load on demand when `[skills] prompt_injection_mode = "compact"` (default keeps context small).
+
+**Enable image/TTS/STT tools:**
+```bash
+zeroclaw config set image_gen.enabled true --no-interactive      # needs FAL_API_KEY
+zeroclaw config set tts.enabled true --no-interactive            # needs an OpenAI-compatible TTS key
+zeroclaw config set transcription.enabled true --no-interactive  # Groq/OpenAI/local-whisper
+```
+These tools are lazy — enabling without a key is harmless; calls just error until a key exists.
+
+**Verify:**
+```bash
+systemctl --user restart zeroclaw.service && sleep 8
+cat ~/.zeroclaw/state/daemon_state.json | python3 -c "import json,sys; d=json.load(sys.stdin); [print(k,'->',c.get('status')) for k,c in d['components'].items()]"
+journalctl --user -u zeroclaw.service --no-pager | grep -iE "mcp|skills" | tail
+# MCP servers spawn on first agent request; check runtime-trace.jsonl for mcp_client activity.
+```
+Note: on CPU-only local models (e.g. `qwen2.5-coder:7b`), the agent loop is very slow — a simple prompt can take minutes. The tooling works; throughput is model-bound.
+
 ## Troubleshooting
 
 **Symptom: `zeroclaw channel send --channel-id telegram` fails with 401 Unauthorized**


### PR DESCRIPTION
Adds a reusable workflow for debugging pytest tests that pass alone but fail under shuffled/randomized order.

- Seeded-shuffle reproduction with pinned, printed seed
- Ordered-window bisection that always appends the failing target test (handles multi-polluter windows)
- Checklist of the common leak patterns: sys.modules pop without restore, in-place importlib.reload rebinding module-level names, shared module-level singletons, stale import references
- Read-only state-tracking hook with correct makereport timing (pytest_runtest_teardown fires before core fixture teardown)
- Clean-run verification guidance (instrumented runs can diverge)

Generic — no private data or project-specific paths.