### PR TITLE
Add analyze-android-apk skill

### DIFF
--- a/skills/analyze-android-apk/SKILL.md
+++ b/skills/analyze-android-apk/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: analyze-android-apk
+description: "Decompile and analyze Android APKs (manifest, permissions, activities, SDKs, endpoints) using portable Java + jadx with no root required. Use when: (1) User shares an .apk or extracted APK folder and asks what it does, (2) Security/privacy review of an Android app, or (3) Inspecting app code, permissions, or network endpoints."
+---
+
+# Analyze Android APK
+
+Decompile any Android APK into readable Java sources and a decoded manifest, then extract identity, permissions, components, bundled SDKs, and hardcoded endpoints. Works fully in user space — no root and no sudo needed.
+
+## Quick quality checklist
+
+- `name` matches folder name exactly (kebab-case)
+- All examples are tested and runnable
+- Uses free/public tools only
+- No secrets, API keys, or personal data in examples
+
+## When to use
+
+- Use case 1: User provides an `.apk` file (or an already-unzipped APK directory) and wants to know what the app does.
+- Use case 2: Privacy/security review: permissions, trackers, plaintext endpoints, self-update mechanisms.
+- Use case 3: Locating specific logic inside an app (pairing protocol, update check, license validation).
+
+## Required tools / APIs
+
+No external API required. Two portable tools installed to `~/.local/opt` (no sudo):
+
+- **Temurin JRE 21** — runtime for jadx
+- **jadx** — DEX/APK decompiler producing Java sources + decoded resources
+
+Install options:
+
+```bash
+# Portable install (works without sudo, Linux x86_64)
+mkdir -p ~/.local/opt /tmp/apk-work
+curl -sL -o /tmp/apk-work/jre.tar.gz \
+  "https://api.adoptium.net/v3/binary/latest/21/ga/linux/x64/jre/hotspot/normal/eclipse"
+tar -xzf /tmp/apk-work/jre.tar.gz -C ~/.local/opt
+
+curl -sL -o /tmp/apk-work/jadx.zip \
+  "https://github.com/skylot/jadx/releases/download/v1.5.4/jadx-1.5.4.zip"
+mkdir -p ~/.local/opt/jadx && unzip -qo /tmp/apk-work/jadx.zip -d ~/.local/opt/jadx
+chmod +x ~/.local/opt/jadx/bin/*
+
+# System package alternative (requires sudo)
+sudo apt-get install -y default-jre-headless   # then still install jadx from GitHub releases
+```
+
+## Skills
+
+### basic_usage
+
+Shortest reliable path: set env, decompile, read manifest.
+
+```bash
+export JAVA_HOME=$(echo ~/.local/opt/jdk-*-jre | tail -1)
+export PATH="$JAVA_HOME/bin:$HOME/.local/opt/jadx/bin:$PATH"
+
+jadx --version   # sanity check, expect 1.5.x
+
+# Decompile (exit code 3 = finished with minor errors; normal for large apps)
+jadx -j 4 -d /tmp/apk-work/out /path/to/app.apk > /tmp/apk-work/jadx.log 2>&1
+
+cat /tmp/apk-work/out/resources/AndroidManifest.xml   # now readable XML
+```
+
+### robust_usage
+
+Full analysis pass with error handling and structured extraction.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+APK="$1"; OUT="${2:-/tmp/apk-work/out}"
+[ -f "$APK" ] || { echo "Error: $APK not found" >&2; exit 1; }
+
+export JAVA_HOME=$(echo ~/.local/opt/jdk-*-jre | tail -1)
+export PATH="$JAVA_HOME/bin:$HOME/.local/opt/jadx/bin:$PATH"
+
+if ! jadx -j 4 -d "$OUT" "$APK" >"$OUT.log" 2>&1; then
+  echo "Note: jadx exited nonzero; check $OUT.log (minor errors are common)" >&2
+fi
+
+M="$OUT/resources/AndroidManifest.xml"
+echo "== Identity =="
+grep -oE 'package="[^"]+"|versionName="[^"]*"|versionCode="[^"]*"' "$M"
+echo "== Permissions =="
+grep -oE 'android:name="android.permission.[A-Z_]+"' "$M" | sort -u
+echo "== Activities =="
+grep -oE 'android:name="[^"]*Activity"' "$M" | sort -u
+echo "== Hardcoded URLs =="
+grep -rEoh 'https?://[a-zA-Z0-9./_?=&-]+' "$OUT/sources" 2>/dev/null | sort | uniq -c | sort -rn | head -20
+```
+
+Useful follow-up greps:
+
+```bash
+# Bundled third-party SDKs (trackers, ads, vendor libs)
+ls "$OUT/sources/com"
+
+# Find where a URL/string is used
+grep -rl "example.endpoint.com" "$OUT/sources"
+
+# App strings (app name, messages)
+grep -oE '<string name="app_name">[^<]*' "$OUT/resources/res/values/strings.xml"
+```
+
+## Output format
+
+Report these fields to the user:
+
+- `package`: application ID (e.g., `com.vendor.app`)
+- `version`: versionName + versionCode
+- `purpose`: 1-3 sentence description of what the app does, inferred from activity/service names
+- `permissions_notable`: dangerous/system-level permissions worth flagging
+- `sdks`: third-party SDKs found under `sources/com/*` (analytics, ads, web kernels)
+- `endpoints`: table of hardcoded URLs/IPs and likely purpose
+- `risk_notes`: plaintext HTTP, hardcoded IPs, self-update/install permissions, telemetry SDKs
+- Error shape: if decompile fails entirely, quote last lines of the jadx log + suggest `--no-res` retry
+
+## Rate limits / Best practices
+
+- Only download tools once; reuse `~/.local/opt` installs across sessions.
+- Decompile to `/tmp`, copy only what is worth keeping to user-visible folders (sources can exceed 100 MB).
+- Exit code 3 from jadx means partial errors — inspect the log before declaring failure.
+- Prefer analyzing the original `.apk`; an extracted APK folder lacks central directory metadata but its `classes*.dex` can be passed to jadx individually.
+- Respect copyright: analysis is fine; do not redistribute decompiled vendor code.
+
+## Agent prompt
+
+```text
+You have analyze-android-apk capability. When a user asks what an APK does or to audit it:
+
+1. Verify the input path exists (.apk file or extracted folder).
+2. Ensure portable JRE + jadx are installed under ~/.local/opt; install if missing.
+3. Run jadx decompilation to a temp output dir; tolerate exit code 3.
+4. Extract identity, permissions, activities, SDK list, and hardcoded URLs using the greps in this skill.
+5. Return the report in the defined Output format, flagging privacy/security risks.
+
+Always prefer the portable no-sudo install over system packages.
+```
+
+## Troubleshooting
+
+**`jadx: Permission denied`:**
+- Symptom: launcher script not executable after unzip.
+- Solution: `chmod +x ~/.local/opt/jadx/bin/*`
+
+**`java: command not found` when running jadx:**
+- Symptom: JAVA_HOME not exported in current shell.
+- Solution: re-export `JAVA_HOME=$(echo ~/.local/opt/jdk-*-jre | tail -1)` and prepend `$JAVA_HOME/bin` to PATH.
+
+**Manifest unreadable / binary garbage:**
+- Symptom: reading `AndroidManifest.xml` from the raw APK zip shows binary AXML.
+- Solution: use the jadx-decoded copy at `<out>/resources/AndroidManifest.xml`.
+
+**Out of memory on huge APKs:**
+- Symptom: jadx crashes or hangs near end of processing.
+- Solution: add `JAVA_OPTS="-Xmx4g"` before jadx, or run with `--no-res` if resources are not needed.
+
+## See also
+
+- [../using-web-scraping/SKILL.md](../using-web-scraping/SKILL.md) — fetch vendor sites referenced by an app for extra context
+- [../phone-specs-scraper/SKILL.md](../phone-specs-scraper/SKILL.md) — research the devices an app targets

--- a/skills/analyze-android-apk/SKILL.md
+++ b/skills/analyze-android-apk/SKILL.md
@@ -87,6 +87,12 @@ echo "== Permissions =="
 grep -oE 'android:name="android.permission.[A-Z_]+"' "$M" | sort -u
 echo "== Activities =="
 grep -oE 'android:name="[^"]*Activity"' "$M" | sort -u
+# Verify the signing certificate (weak crypto, self-signing, validity window)
+keytool -printcert -jarfile "$APK" 2>/dev/null || {
+  unzip -o -q "$APK" "META-INF/*.RSA" -d /tmp/apk-work/meta
+  keytool -printcert -file "$(ls /tmp/apk-work/meta/META-INF/*.RSA | head -1)"
+}
+
 echo "== Hardcoded URLs =="
 grep -rEoh 'https?://[a-zA-Z0-9./_?=&-]+' "$OUT/sources" 2>/dev/null | sort | uniq -c | sort -rn | head -20
 ```
@@ -114,7 +120,8 @@ Report these fields to the user:
 - `permissions_notable`: dangerous/system-level permissions worth flagging
 - `sdks`: third-party SDKs found under `sources/com/*` (analytics, ads, web kernels)
 - `endpoints`: table of hardcoded URLs/IPs and likely purpose
-- `risk_notes`: plaintext HTTP, hardcoded IPs, self-update/install permissions, telemetry SDKs
+- `signing_cert`: owner/issuer, validity window, algorithm; flag SHA1 signatures or RSA keys < 2048 bits as weak, and self-signed certs
+- `risk_notes`: plaintext HTTP, hardcoded IPs, self-update/install permissions, telemetry SDKs, weak signing crypto
 - Error shape: if decompile fails entirely, quote last lines of the jadx log + suggest `--no-res` retry
 
 ## Rate limits / Best practices

--- a/skills/facebook-page-manager/SKILL.md
+++ b/skills/facebook-page-manager/SKILL.md
@@ -98,6 +98,7 @@ const sched = await graph(`${pageId}/scheduled_posts`, { fields: "id,created_tim
 - **System users often cannot reply to existing comments** (`error 100 subcode 33 "does not support this operation"`) even with `pages_manage_engagement` — while creating a new comment on a post works. Make the reply loop resilient (try/catch per comment, mark seen, log and continue) so one failure doesn't halt the poll.
 - **Scheduling unit bug**: `scheduled_publish_time` is unix *seconds*. If you build times as `Date.now() + step` where `step` is in seconds, posts get scheduled ~40s ahead and flood the page every minute. Convert: `Math.floor(Date.now() / 1000) + stepSeconds`.
 - **Stale dry-run posts block live scheduling**: after running in dry-run, the local store holds fake `post_1`-style scheduled entries that never exist on Facebook. `topUp()` counts them as filled slots and never schedules real posts. On each live tick, reconcile against `GET /{page}/scheduled_posts` and drop local scheduled entries that aren't real.
+- **Overlapping scheduler ticks double-schedule**: if the tick (content generation + API calls) takes longer than the cron interval, two ticks run concurrently and both see "missing slots" → posts get scheduled a minute apart. Guard the tick with a `running` flag (async mutex), and count open slots from the live `/scheduled_posts` list rather than the local store.
 - **Always ship a `DRY_RUN` mode** so the whole pipeline runs and is testable before any credentials exist.
 
 ## Minimal agent loop (Node.js)

--- a/skills/facebook-page-manager/SKILL.md
+++ b/skills/facebook-page-manager/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: facebook-page-manager
+description: "Build and deploy an autonomous Facebook page agent in Node.js (Graph API posting, scheduling, comment replies, analytics, monetization tracking) and take it from dry-run to live production. Use when the user wants to automate, grow, or monetize a Facebook page with minimal human involvement."
+---
+
+# Facebook Page Manager Agent
+
+Builds a standalone Node.js agent that manages a Facebook page: AI-drafted content,
+scheduled posting cadence, comment auto-replies, analytics, and monetization-gate
+tracking. Covers the credential setup, the Graph API pitfalls that block "going
+live", and deploying it as a long-running service so it runs without human help.
+
+## When to use
+
+- User asks to "build a Facebook agent / automate a Facebook page / grow a page"
+- User wants scheduled posting, comment auto-replies, or monetization tracking
+- User asks to make the agent "run on its own / continue without our help"
+- Taking an existing dry-run Facebook agent into production
+
+## Required tools / APIs
+
+- **Facebook Graph API** (free): page posting, scheduling, comments, insights. Requires a Facebook Developer app + token.
+- **System User token** (free, recommended for autonomy): never expires. Created in Business Manager.
+- **Local LLM via ollama** (free, optional): content drafting. Any OpenAI-compatible endpoint works.
+- **node-cron / telegraf** (free): scheduler + optional Telegram control.
+
+```bash
+npm install node-cron telegraf dotenv
+```
+
+## Credential setup (the 90% blocker)
+
+For an agent that runs unattended, use a **System User token** because it never
+expires (regular user tokens die in ~60 days; Explorer tokens die in hours).
+
+1. Create a developer app at https://developers.facebook.com → My Apps → Create App → Business. Add the **Facebook Login** product. Keep it in **Development mode**.
+2. Create a system user: https://business.facebook.com/settings/system-users → Create → Generate New Token → select your app.
+3. Select **all** these permissions (each is needed):
+   - `pages_show_list` — list pages
+   - `pages_read_engagement` — read posts
+   - `pages_manage_posts` — post / schedule
+   - `pages_manage_engagement` — comment replies
+   - `pages_read_user_content` — read comment text
+   - `read_insights` — analytics metrics
+4. Assign the page to the system user (Business Settings → System Users → user → Assign assets → the page).
+5. Verify with the debug endpoint:
+   ```bash
+   curl -s "https://graph.facebook.com/v21.0/debug_token?input_token=TOKEN&access_token=TOKEN"
+   ```
+   Confirm `type: SYSTEM_USER`, `expires_at: 0`, and all 6 scopes present.
+
+## Graph API client (Node.js)
+
+```javascript
+const BASE = "https://graph.facebook.com/v21.0";
+let userToken = process.env.FB_USER_TOKEN;   // system user token
+let pageToken = null;
+
+async function pageTokenFor(pageId) {
+  if (pageToken) return pageToken;
+  const res = await fetch(`${BASE}/me/accounts?fields=id,access_token&access_token=${userToken}`);
+  const data = await res.json();
+  pageToken = data.data.find((p) => String(p.id) === String(pageId))?.access_token;
+  if (!pageToken) throw new Error("page not linked to this token");
+  return pageToken;
+}
+
+async function graph(path, params = {}, method = "GET", token = userToken) {
+  const url = new URL(`${BASE}/${path}`);
+  if (method === "GET") Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  url.searchParams.set("access_token", token);
+  const opts = { method };
+  if (method !== "GET") { opts.headers = { "Content-Type": "application/json" }; opts.body = JSON.stringify({ ...params, access_token: token }); }
+  const res = await fetch(url, opts);
+  const data = await res.json();
+  if (data.error) throw new Error(`Graph API ${data.error.code}: ${data.error.message}`);
+  return data;
+}
+
+// read posts (use /posts, NOT /feed — see gotchas)
+const feed = await graph(`${pageId}/posts`, { limit: 25, fields: "id,message,created_time,comments.limit(10){id,message,created_time}" }, "GET", await pageTokenFor(pageId));
+// schedule a post (unix SECONDS, published:false)
+await graph(`${pageId}/feed`, { message, published: false, scheduled_publish_time: Math.floor(Date.now() / 1000) + 8 * 3600 }, "POST", await pageTokenFor(pageId));
+// reply to a comment
+await graph(`${commentId}/replies`, { message }, "POST", await pageTokenFor(pageId));
+// insights
+await graph(`${pageId}/insights`, { metric: "page_fans,page_impressions,page_engaged_users,page_video_views", period: "day" }, "GET", await pageTokenFor(pageId));
+// current scheduled posts (ground truth for reconciliation)
+const sched = await graph(`${pageId}/scheduled_posts`, { fields: "id,created_time" }, "GET", await pageTokenFor(pageId));
+```
+
+## Production gotchas (learned the hard way)
+
+- **`/feed` reads are broken for many accounts** — `GET /{page}/feed` returns `error 10 requires pages_read_engagement` even with the permission granted. Use `GET /{page}/posts` instead. (POSTing to `/feed` is fine; only *reading* `/feed` is broken.)
+- **The new Pages experience requires a PAGE token** for `/posts`, `/scheduled_posts`, etc. A system-user or user token fails with `error 190 subcode 2069032`. Derive the page token from `/me/accounts` (page tokens don't expire for pages you administer) and use it for all page-scoped calls.
+- **Missing `read_insights` masks as `error 100 "The value must be a valid insights metric"`** for any metric — it's a permission problem, not a metric problem.
+- **Reading comment text needs `pages_read_user_content`** on top of `pages_read_engagement`.
+- **System users often cannot reply to existing comments** (`error 100 subcode 33 "does not support this operation"`) even with `pages_manage_engagement` — while creating a new comment on a post works. Make the reply loop resilient (try/catch per comment, mark seen, log and continue) so one failure doesn't halt the poll.
+- **Scheduling unit bug**: `scheduled_publish_time` is unix *seconds*. If you build times as `Date.now() + step` where `step` is in seconds, posts get scheduled ~40s ahead and flood the page every minute. Convert: `Math.floor(Date.now() / 1000) + stepSeconds`.
+- **Stale dry-run posts block live scheduling**: after running in dry-run, the local store holds fake `post_1`-style scheduled entries that never exist on Facebook. `topUp()` counts them as filled slots and never schedules real posts. On each live tick, reconcile against `GET /{page}/scheduled_posts` and drop local scheduled entries that aren't real.
+- **Always ship a `DRY_RUN` mode** so the whole pipeline runs and is testable before any credentials exist.
+
+## Minimal agent loop (Node.js)
+
+```javascript
+const cron = require("node-cron");
+const { graph, pageTokenFor } = require("./graph");   // as above
+
+async function topUp(pageId, postsPerDay) {
+  const now = Date.now();
+  const horizon = now + 24 * 3600 * 1000;
+  const real = await graph(`${pageId}/scheduled_posts`, { fields: "id,created_time" }, "GET", await pageTokenFor(pageId));
+  const slots = real.data.filter((p) => new Date(p.created_time).getTime() > now && new Date(p.created_time).getTime() <= horizon);
+  const missing = Math.max(0, postsPerDay - slots.length);
+  for (let i = 0; i < missing; i++) {
+    const step = (24 * 3600 * 1000) / postsPerDay;
+    const when = Math.floor((now + step * (i + 1)) / 1000);
+    await graph(`${pageId}/feed`, { message: `Draft #${i}`, published: false, scheduled_publish_time: when }, "POST", await pageTokenFor(pageId));
+  }
+}
+
+cron.schedule("* * * * *", () => topUp("PAGE_ID", 3).catch((e) => console.error(e.message)));
+```
+
+## Deploy as an always-on service
+
+Systemd user service survives reboots and auto-restarts on crash:
+
+```ini
+[Unit]
+Description=Facebook Page Agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/USER/facebook-agent
+ExecStart=/usr/bin/node src/index.js
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+```
+
+```bash
+mkdir -p ~/.config/systemd/user
+# write the unit to ~/.config/systemd/user/facebook-agent.service
+systemctl --user daemon-reload
+systemctl --user enable --now facebook-agent
+loginctl enable-linger USER   # keep running after logout (sudo if needed)
+journalctl --user -u facebook-agent -f   # watch logs
+```
+
+## Output format
+
+The agent should report:
+- Page: name, id, live/dry-run mode
+- Scheduled jobs: id, time, preview
+- Followers and monetization-gate progress (% toward 10k followers, 30k 1-min video views / 60d)
+- Errors as `Graph API <code>: <message>` plus the fix (permission / token / endpoint)
+
+## Rate limits / Best practices
+
+- Back off on HTTP 429 / 5xx (retry up to 3x with exponential delay).
+- Never reply to the same comment twice — persist seen ids.
+- Keep tokens in `.env` (git-ignored); never commit or log them.
+- Verify `GET /debug_token` scopes before blaming the agent code.
+- Meta's actual monetization rules change — verify eligibility in the page's Professional Dashboard before promising monetization.
+
+## Agent prompt
+
+```text
+You have Facebook Page Manager capability. When a user asks to build or run a Facebook page agent:
+1. Check credentials: do they have a developer app + token? Recommend a System User token (never expires) with all 6 permissions. Verify via /debug_token.
+2. Build the agent as a standalone Node service: Graph client (page token via /me/accounts), content generator (local ollama first), scheduler, engagement poller, analytics, monetization tracker. Always DRY_RUN first.
+3. On going live: read posts via /posts not /feed, reconcile topUp against /scheduled_posts, convert scheduled_publish_time to unix seconds, make comment replies per-comment resilient.
+4. Deploy as a systemd user service with restart=always and enable-linger so it runs unattended.
+```
+
+## Troubleshooting
+
+**`error 10 ... requires pages_read_engagement` on GET /{page}/feed**
+- Use `GET /{page}/posts` instead. If it persists there, the token's page token may be missing `pages_read_engagement` — recheck `/debug_token`.
+
+**`error 190 subcode 2069032 "Page access token is required"`**
+- New Pages experience: derive a page token via `/me/accounts` and use it for page-scoped calls.
+
+**`error 100 "The value must be a valid insights metric"`**
+- Missing `read_insights`. Regenerate the system user token with `read_insights` selected.
+
+**`error 100 subcode 33` on comment replies**
+- Known system-user limitation. Creating comments works; replying to other users' comments may be blocked. Keep the reply loop resilient and try again after assigning the system user a full-control page role.
+
+**Posts scheduling ~40 seconds apart / flooding the page**
+- Unit bug: `scheduled_publish_time` is unix seconds; `Date.now()` is milliseconds. Convert before sending.
+
+**Agent runs but never schedules real posts**
+- Stale local "scheduled" entries from dry-run are blocking topUp. Reconcile local store against `GET /{page}/scheduled_posts` and drop fake entries.
+
+**`error 190` token expired (user tokens only)**
+- System user tokens don't expire; switch to one. Otherwise re-run the `fb_exchange_token` step.
+
+## See also
+
+- [../using-telegram-bot/SKILL.md](../using-telegram-bot/SKILL.md) — Telegraf patterns for the optional control bot
+- [../humanizer/SKILL.md](../humanizer/SKILL.md) — tone adjustments for AI-drafted page content


### PR DESCRIPTION
Adds a reusable skill for decompiling and analyzing Android APKs with portable Java 21 + jadx (no sudo required). Covers: identity/permission extraction, activity listing, bundled SDK detection, hardcoded endpoint discovery, output report format, troubleshooting, and an agent prompt. Tested end-to-end on a real vendor APK.