### PR TITLE
Add freqtrade-strategy-backtest

### DIFF
--- a/skills/freqtrade-plugin-activation/SKILL.md
+++ b/skills/freqtrade-plugin-activation/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: freqtrade-plugin-activation
+description: "Audit and activate freqtrade bot add-ons: FreqUI web dashboard, API server credentials, Telegram alerts. Use when: (1) User asks what plugins/features are active on a freqtrade bot, (2) User wants browser monitoring or Telegram notifications enabled, or (3) User explicitly asks to harden a freqtrade config."
+---
+
+# Freqtrade Plugin Activation
+
+Audit which optional freqtrade components are active and enable missing ones: FreqUI (browser dashboard), secured API server, and Telegram alerting. Outcome: a running bot with remote monitoring and control.
+
+## Quick quality checklist
+
+- `name` matches folder name exactly (kebab-case)
+- All examples tested against freqtrade 2025+ venv installs
+- Uses only freqtrade built-ins (no paid services)
+- No tokens, keys, or personal paths in examples
+
+## When to use
+
+- Use case 1: "Is FreqUI/Telegram/protections active on my bot?"
+- Use case 2: Before going live — verify monitoring and controls exist
+- Use case 3: After installing freqtrade from source into a `.venv`
+
+## Required tools / APIs
+
+- freqtrade CLI inside the project venv
+- jq or python3 for JSON inspection of `user_data/config.json`
+- Telegram bot token (free, from @BotFather) — only for the Telegram step
+
+## Skills
+
+### audit_plugins
+
+One-shot status check of every pluggable component.
+
+```bash
+# Run from the freqtrade source/project root; adjust paths
+python3 - <<'EOF'
+import json
+c = json.load(open("user_data/config.json"))
+api = c.get("api_server", {})
+tg = c.get("telegram", {})
+print("dry_run:        ", c.get("dry_run"))
+print("strategy:       ", c.get("strategy"))
+print("pairlists:      ", [p["method"] for p in c.get("pairlists", [])])
+print("protections_cfg:", "protections" in c)          # may live in strategy file instead
+print("api_server:     ", api.get("enabled"), api.get("listen_ip_address") + ":" + str(api.get("listen_port")))
+print("jwt_default:    ", api.get("jwt_secret_key", "").startswith("CHANGE_THIS"))
+print("telegram:       ", tg.get("enabled"), "(token placeholder)" if tg.get("token", "").startswith("YOUR_") else "")
+EOF
+
+# Protections defined in the strategy instead?
+grep -n "protections" user_data/strategies/<StrategyName>.py
+
+# Is the REST API actually listening?
+ss -tlnp | grep <port>   # default 8080; often remapped to 8081
+
+# FreqUI installed? (path differs for source checkouts)
+ls freqtrade/rpc/api_server/ui/installed/index.html 2>/dev/null || echo "FreqUI missing"
+```
+
+Interpretation:
+
+- `jwt_default` true → replace secret before any non-localhost binding
+- Pairlist chain present + protections found → core risk plugins OK
+- FreqUI missing → run install step below
+
+### install_frequi
+
+```bash
+VENV/bin/freqtrade install-ui          # downloads/serves FreqUI at http://127.0.0.1:<port>
+# Source checkout note: assets land in freqtrade/freqtrade/rpc/api_server/ui/installed/
+```
+
+### secure_api_server
+
+Generate secrets, then patch `user_data/config.json`.
+
+```bash
+python3 -c "import secrets; print(secrets.token_urlsafe(48))"   # jwt_secret_key
+python3 -c "import secrets; print(secrets.token_urlsafe(18))"   # password
+```
+
+Set inside `api_server`:
+
+```json
+{
+  "enabled": true,
+  "listen_ip_address": "127.0.0.1",
+  "jwt_secret_key": "<generated>",
+  "username": "<chosen-user>",
+  "password": "<generated>"
+}
+```
+
+Validate before restart:
+
+```bash
+python3 -m json.tool user_data/config.json > /dev/null && echo "config valid"
+VENV/bin/freqtrade show-config -c user_data/config.json | grep username
+```
+
+### wire_telegram
+
+Requires: bot token from @BotFather and the owner's chat_id.
+
+```bash
+# 1. Confirm token works
+curl -fsS --max-time 10 "https://api.telegram.org/bot<TOKEN>/getMe"
+
+# 2. Auto-discover chat_id: user sends ANY message to the bot first, then:
+curl -fsS --max-time 10 "https://api.telegram.org/bot<TOKEN>/getUpdates" \
+  | python3 -c "import json,sys; u=json.load(sys.stdin)['result']; print(u[-1]['message']['chat']['id'])"
+
+# 3. Patch telegram block in config:
+#    {"enabled": true, "token": "<TOKEN>", "chat_id": "<CHAT_ID>"}
+# 4. Restart bot; verify with /status sent to the bot in Telegram
+```
+
+### apply_changes
+
+Config edits require a restart; open trades persist in the DB across restarts.
+
+```bash
+kill <bot_pid> && sleep 5
+VENV/bin/freqtrade trade --config user_data/config.json --userdir user_data --strategy <StrategyName> &
+```
+
+## Output format
+
+Per-component verdict table:
+
+| Component | State | Action |
+|---|---|---|
+| FreqUI | installed/missing | install-ui |
+| API creds | secure/default | rotate jwt+password |
+| Telegram | on/off/placeholder | wire token+chat_id |
+| Protections | strategy/config/absent | add if absent |
+
+Error shape: `<component>: FAILED — <reason> — <fix command>`.
+
+## Rate limits / Best practices
+
+- Never bind api_server to 0.0.0.0 without a reverse proxy + TLS
+- Rotate `jwt_secret_key` whenever a password leaks; treat bot tokens as secrets
+- Restart during flat market hours; freqtrade restores open trades from the DB
+- Keep `stoploss_on_exchange` false on spot unless the exchange supports it reliably
+
+## Agent prompt
+
+```text
+You have freqtrade-plugin-activation capability. When a user asks about bot plugins,
+monitoring, or notifications:
+
+1. Run the audit_plugins snippet; classify each component as active/inactive/insecure
+2. Enable what the user approves: install-ui, credential rotation, telegram wiring
+3. For Telegram, auto-discover chat_id via getUpdates instead of asking the user
+4. Validate JSON after every edit; restart only with explicit user consent
+5. Report the per-component table with actions taken
+```
+
+## Troubleshooting
+
+**install-ui says up-to-date but no dashboard loads**
+- Symptom: 404 at http://127.0.0.1:8081
+- Solution: source checkouts nest the package (`freqtrade/freqtrade/rpc/...`); check there, restart bot after first install
+
+**getUpdates returns empty result**
+- Symptom: cannot detect chat_id
+- Solution: user must send a message to the bot first; re-poll after
+
+**Telegram silently disabled at startup**
+- Symptom: log line "Telegram ... is not enabled"
+- Solution: token still placeholder or `enabled: false`; also confirm network egress to api.telegram.org
+
+## See also
+
+- [../database-query-and-export/SKILL.md](../database-query-and-export/SKILL.md) — query the trades SQLite DB directly
+- [../get-crypto-price/SKILL.md](../get-crypto-price/SKILL.md) — price checks for open-position P&L

--- a/skills/freqtrade-strategy-backtest/SKILL.md
+++ b/skills/freqtrade-strategy-backtest/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: freqtrade-strategy-backtest
+description: "Backtest a freqtrade strategy against local OHLCV data and compare candidates on identical windows. Use when: (1) User asks to backtest or validate a trading strategy, (2) User wants a before/after comparison of two strategies, or (3) Backtesting fails because the live config uses dynamic pairlists."
+---
+
+# Freqtrade Strategy Backtest
+
+Run reproducible freqtrade backtests from local feather/JSON data and produce an apples-to-apples comparison of candidate strategies. Outcome: summary metrics table (profit %, Sharpe, profit factor, exit breakdown) per strategy over the same timerange.
+
+## Quick quality checklist
+
+- `name` matches folder name exactly (kebab-case)
+- Commands tested against freqtrade 2025+ venv installs
+- Uses freqtrade built-ins only, no paid data services
+- No personal paths, keys, or exchange credentials in examples
+
+## When to use
+
+- Use case 1: "Test this new strategy before going live"
+- Use case 2: "Compare my current strategy vs a proposed one"
+- Use case 3: `ERROR - Pairlist Handlers ... do not support backtesting`
+
+## Required tools / APIs
+
+- freqtrade CLI in project venv
+- Locally downloaded OHLCV data (`user_data/data/<exchange>/*.feather`)
+
+Download data if missing:
+
+```bash
+VENV/bin/freqtrade download-data --config user_data/config.json --userdir user_data \
+  --timeframe 3m --timerange 20260501- --pairs BTC/USDT ETH/USDT
+```
+
+## Skills
+
+### static_pairlist_override
+
+Live configs with VolumePairList/AgeFilter/etc. cannot backtest. Never edit the live config — overlay a minimal override config instead:
+
+```bash
+cat > user_data/config.backtest.json <<'EOF'
+{
+    "pairlists": [
+        {
+            "method": "StaticPairList"
+        }
+    ]
+}
+EOF
+
+# Later -c files override earlier ones; live config stays untouched
+VENV/bin/freqtrade backtesting \
+  --config user_data/config.json \
+  --config user_data/config.backtest.json \
+  --userdir user_data \
+  --strategy <StrategyName> \
+  --timeframe 3m \
+  --timerange YYYYMMDD-YYYYMMDD \
+  --pairs BTC/USDT ETH/USDT SOL/USDT
+```
+
+### compare_candidates
+
+Run each strategy with identical `--timeframe`, `--timerange`, and `--pairs`, then diff the SUMMARY METRICS blocks:
+
+```bash
+for S in StrategyA StrategyB; do
+  VENV/bin/freqtrade backtesting \
+    --config user_data/config.json --config user_data/config.backtest.json \
+    --userdir user_data --strategy "$S" --timeframe 3m \
+    --timerange YYYYMMDD-YYYYMMDD --pairs BTC/USDT ETH/USDT \
+    > "/tmp/${S}_backtest.log" 2>&1
+done
+
+grep -h "Total profit %\|Sharpe\|Profit factor\|Market change" /tmp/*_backtest.log
+```
+
+Key metrics for verdicts:
+
+- `Total profit %` vs `Market change` (underperforming a bull market = broken)
+- `Profit factor` (>1.5 acceptable, >2 good), `Sharpe`
+- `EXIT REASON STATS`: stop_loss share and avg loss vs roi gains
+- Win rate alone is misleading — check what the losses cost
+
+## Output format
+
+Per-strategy row + verdict:
+
+- Field 1: strategy name (string)
+- Field 2: trades, total profit %, Sharpe, profit factor, stop-loss count
+- Field 3: verdict — keep-live / reject / needs-hyperopt, one line why
+- Error shape: `<stage>: FAILED — <freqtrade error line> — <fix>` (e.g. pairlist error → apply StaticPairList overlay)
+
+## Rate limits / Best practices
+
+- Keep risk settings identical across compared strategies so only signals differ
+- Leave >= startup_candle_count of data before the backtest start date
+- Treat results as invalid if logs warn about lookahead bias (e.g. PriceFilter)
+- Re-run across two disjoint timeranges before trusting any edge
+
+## Agent prompt
+
+```text
+You have freqtrade-strategy-backtest capability. When a user asks to test or compare
+strategies:
+
+1. Verify local OHLCV data exists for the requested pairs/timeframe; download if absent
+2. If the config has dynamic pairlists, create/use the StaticPairList override config
+3. Backtest each candidate with identical window/pairs/timeframe into separate logs
+4. Extract Total profit %, Sharpe, Profit factor, Market change, exit-reason breakdown
+5. Return a one-row-per-strategy table plus a keep/reject/hyperopt verdict
+```
+
+## Troubleshooting
+
+**Pairlist Handlers ... do not support backtesting**
+- Symptom: ERROR listing VolumePairList etc.
+- Solution: apply the StaticPairList overlay config as a second `-c`
+
+**unrecognized arguments: --pairlists**
+- Symptom: CLI rejects `--pairlists StaticPairList`
+- Solution: not a valid flag on this version; use the override config file instead
+
+**Empty result / no trades**
+- Symptom: 0 trades over range
+- Solution: check data coverage (`list-data`), lower entry thresholds, confirm signals fire via `backtesting-analysis`
+
+## See also
+
+- [../freqtrade-plugin-activation/SKILL.md](../freqtrade-plugin-activation/SKILL.md) — audit/activate bot plugins
+- [../trading-indicators-from-price-data/SKILL.md](../trading-indicators-from-price-data/SKILL.md) — compute indicators outside freqtrade


### PR DESCRIPTION
Adds a skill for running reproducible freqtrade backtests: StaticPairList override config for live configs with dynamic pairlists, candidate comparison methodology with identical windows/risk settings, metric interpretation (profit vs market change, profit factor, exit-reason stats), and troubleshooting for common backtest failures.